### PR TITLE
feat(lead): allow adding extra classes by the class parameter

### DIFF
--- a/layouts/partials/bootstrap/lead.html
+++ b/layouts/partials/bootstrap/lead.html
@@ -1,1 +1,5 @@
-<p class="lead">{{ . }}</p>
+{{- $class := "" }}
+{{- if .IsNamedParams }}
+  {{- with .Get "class" }}{{ $class = . }}{{ end }}
+{{- end }}
+<p class="lead{{ with $class }} {{ . }}{{ end }}">{{ .Inner }}</p>

--- a/layouts/shortcodes/bootstrap/lead.html
+++ b/layouts/shortcodes/bootstrap/lead.html
@@ -1,1 +1,2 @@
-{{ partial "bootstrap/lead" .Inner }}
+{{- if eq .Inner "" }}{{ end }}
+{{ partial "bootstrap/lead" . }}

--- a/layouts/shortcodes/bs/lead.html
+++ b/layouts/shortcodes/bs/lead.html
@@ -1,1 +1,2 @@
-{{ partial "bootstrap/lead" .Inner }}
+{{- if eq .Inner "" }}{{ end }}
+{{ partial "bootstrap/lead" . }}


### PR DESCRIPTION
For example: `{{< bs/lead class="mb-4" >}}`.