### PR TITLE
WIP: Add support for images in icon-grids

### DIFF
--- a/layouts/partials/bootstrap/icon-grid.html
+++ b/layouts/partials/bootstrap/icon-grid.html
@@ -57,7 +57,7 @@
             <div class="bs-icon-grid-item-title fw-bold mb-3 fs-4 d-flex align-items-center justify-content-{{ $alignment }}">
               {{- with .image }}
                 {{- $imageOpts := (merge (dict
-                    "ClassName" "bs-icon-grid-item-image") .)
+                    "ClassName" "bs-icon-grid-item-image img-fluid") .)
                 }}
                 {{- if isset . "ClassName" }}
                     {{- $imageOpts = merge $imageOpts (dict "ClassName" (printf "bs-icon-grid-item-image %s" (.ClassName)))}}
@@ -77,7 +77,7 @@
             <div class="bs-icon-grid-item-title fw-bold mb-3 fs-4 d-flex align-items-center justify-content-{{ $alignment }}">
               {{- with .image }}
                 {{- $imageOpts := (merge (dict
-                    "ClassName" "bs-icon-grid-item-image") .)
+                    "ClassName" "bs-icon-grid-item-image img-fluid") .)
                 }}
                 {{- if isset . "ClassName" }}
                     {{- $imageOpts = merge $imageOpts (dict "ClassName" (printf "bs-icon-grid-item-image %s" (.ClassName)))}}

--- a/layouts/partials/bootstrap/icon-grid.html
+++ b/layouts/partials/bootstrap/icon-grid.html
@@ -55,6 +55,15 @@
             {{ with $itemAttrs }}{{ delimit . " " | safeHTMLAttr }}{{ end }}
             {{ if $url.Scheme }}target="_blank" rel="external"{{ end }}>
             <div class="bs-icon-grid-item-title fw-bold mb-3 fs-4 d-flex align-items-center justify-content-{{ $alignment }}">
+              {{- with .image }}
+                {{- $imageOpts := (merge (dict
+                    "ClassName" "bs-icon-grid-item-image") .)
+                }}
+                {{- if isset . "ClassName" }}
+                    {{- $imageOpts = merge $imageOpts (dict "ClassName" (printf "bs-icon-grid-item-image %s" (.ClassName)))}}
+                {{- end }}
+                {{- partial "images/image" $imageOpts }}
+              {{- end -}}
               {{- $icon -}}{{- .title -}}
             </div>
             <p class="bs-icon-grid-item-desc mb-0 text-body-secondary">
@@ -68,12 +77,10 @@
             <div class="bs-icon-grid-item-title fw-bold mb-3 fs-4 d-flex align-items-center justify-content-{{ $alignment }}">
               {{- with .image }}
                 {{- $imageOpts := (merge (dict
-                    "width" "1.25em"
-                    "height" "1.25em"
-                    "className" "bs-icon-grid-item-image me-2") .)
+                    "ClassName" "bs-icon-grid-item-image") .)
                 }}
-                {{- if isset . "className" }}
-                    {{- $imageOpts = merge $imageOpts (dict "className" (printf "bs-icon-grid-item-image me-2 %s" (.className)))}}
+                {{- if isset . "ClassName" }}
+                    {{- $imageOpts = merge $imageOpts (dict "ClassName" (printf "bs-icon-grid-item-image %s" (.ClassName)))}}
                 {{- end }}
                 {{- partial "images/image" $imageOpts }}
               {{- end -}}

--- a/layouts/partials/bootstrap/icon-grid.html
+++ b/layouts/partials/bootstrap/icon-grid.html
@@ -66,6 +66,17 @@
             class="bs-icon-grid-item d-flex flex-column rounded h-100 w-100 p-4{{ cond $border ` border shadow` `` }} text-{{ $alignment }}"
             {{ with $itemAttrs }}{{ delimit . " " | safeHTMLAttr }}{{ end }}>
             <div class="bs-icon-grid-item-title fw-bold mb-3 fs-4 d-flex align-items-center justify-content-{{ $alignment }}">
+              {{- with .image }}
+                {{- $imageOpts := (merge (dict
+                    "width" "1.25em"
+                    "height" "1.25em"
+                    "className" "bs-icon-grid-item-image me-2") .)
+                }}
+                {{- if isset . "className" }}
+                    {{- $imageOpts = merge $imageOpts (dict "className" (printf "bs-icon-grid-item-image me-2 %s" (.className)))}}
+                {{- end }}
+                {{- partial "images/image" $imageOpts }}
+              {{- end -}}
               {{- $icon -}}{{- .title -}}
             </div>
             <p class="bs-icon-grid-item-desc mb-0 text-body-secondary">


### PR DESCRIPTION
The code was so small, I was worried that we'd have a lot of cut-and-paste duplication.

See https://goattrails.pst.org/events/2024/03/baja-california/#attendees
Sources:
https://github.com/goattrails/hb-goattrails/tree/main/content/events/2024-baja-mexico/index.md
https://github.com/goattrails/hb-goattrails/tree/main/content/events/2024-baja-mexico/iattendees.yaml

Parameters added:
```
image:
  Filename:
  any other images/image parameters...
```

