### PR TITLE
feat: add the img-grid shortcode

### DIFF
--- a/layouts/partials/bootstrap/img-grid.html
+++ b/layouts/partials/bootstrap/img-grid.html
@@ -1,0 +1,28 @@
+{{- $key := "" }}
+{{- if .IsNamedParams }}
+  {{- $key = .Get "data" }}
+{{- else }}
+  {{- $key = .Get 0 }}
+{{- end }}
+{{- $data := partialCached "bootstrap/functions/data" (dict "key" $key "page" .Page) .Page $key }}
+{{- with $data }}
+<div class="d-flex bs-img-grid flex-wrap gap-1 justify-content-center">
+  {{- range . }}
+    {{- $img := partial "images/image" (dict
+      "Filename" .src
+      "ClassName" "bs-img-grid-item-img"
+      "Alt" .title
+      "Caption" .title)
+    }}
+    {{- if .url }}
+      <a class="bs-img-grid-item text-center" href="{{ .url }}" target="_blank">
+        {{ $img }}
+      </a>
+    {{- else }}
+      <div class="bs-img-grid-item text-center">
+        {{ $img }}
+      </div>
+    {{- end }}
+  {{- end }}
+</div>
+{{- end }}

--- a/layouts/shortcodes/bootstrap/img-grid.html
+++ b/layouts/shortcodes/bootstrap/img-grid.html
@@ -1,0 +1,1 @@
+{{ partial "bootstrap/img-grid" . }}

--- a/layouts/shortcodes/bs/img-grid.html
+++ b/layouts/shortcodes/bs/img-grid.html
@@ -1,0 +1,1 @@
+{{ partial "bootstrap/img-grid" . }}


### PR DESCRIPTION
Related to #100 and #103.

```markdown
{{< bs/img-grid "img-grid-examples" >}}
```

> `img-grid-examples` is the data filename.

`data/img-grid-examples.yaml` as follows:

```html
- src: foo.png
  title: Foo
  url: https://example.org/

- src: bar.png
  title: Bar
```

- src: required, the source/name of image.
- title: required, the title of image, which used as alt and caption.
- url: optional.