### PR TITLE
feat(alert): simplify usage with Markdown content

### DIFF
--- a/assets/mods/bootstrap/scss/_alert.scss
+++ b/assets/mods/bootstrap/scss/_alert.scss
@@ -1,0 +1,5 @@
+.alert-content {
+  > p:last-child {
+    margin-bottom: 0 !important;
+  }
+}

--- a/assets/mods/bootstrap/scss/index.scss
+++ b/assets/mods/bootstrap/scss/index.scss
@@ -1,0 +1,1 @@
+@import 'alert';

--- a/layouts/partials/bootstrap/alert-heading.html
+++ b/layouts/partials/bootstrap/alert-heading.html
@@ -1,4 +1,4 @@
 <div class="alert-heading h5 d-flex">
-  {{ partial "bootstrap/alert-icon" (cond .Parent.IsNamedParams (.Parent.Get "style") (.Parent.Get 0)) }}
-  {{ .Get 0 }}
+  {{- partial "bootstrap/alert-icon" (cond .Parent.IsNamedParams (.Parent.Get "style") (.Parent.Get 0)) -}}
+  {{- .Get 0 -}}
 </div>

--- a/layouts/partials/bootstrap/alert.html
+++ b/layouts/partials/bootstrap/alert.html
@@ -9,5 +9,7 @@
   {{- if not (findRE `alert-heading` .Inner) }}
     {{ partial "bootstrap/alert-icon" $style }}
   {{- end }}
-  <div class="alert-content">{{ .Inner }}</div>
+  <div class="alert-content">
+    {{ .Inner }}
+  </div>
 </div>


### PR DESCRIPTION
Previously, we have to wrap the Markdown content with `markdownify` shortcode as follows.

```markdown
{{< bs/alert primary >}}
{{% markdownify %}}
A simple *primary alert* with Markdown—**check it out**!
{{% /markdownify %}}
{{< /bs/alert >}}
```

Now, with this PR, we can simplify the syntax.

```markdown
{{% bs/alert style=primary %}}
A simple *primary alert* with Markdown—**check it out**!
{{% /bs/alert %}}
```

> Replace `<` symbol with `%`.

But this requires you import a minor style to remove the margin-bottom of last `<p>` element.

```
.alert-content {
  > p:last-child {
    margin-bottom: 0 !important;
  }
}
```

You can either import the `mods/bootstrap/scss/index` SCSS via Hugo Pipes.