### PR TITLE
make sure bs-img always gets the proper .Page

### DIFF
--- a/layouts/partials/bootstrap/img-grid.html
+++ b/layouts/partials/bootstrap/img-grid.html
@@ -4,11 +4,13 @@
 {{- else }}
   {{- $key = .Get 0 }}
 {{- end }}
+{{- $page := .Page }}
 {{- $data := partialCached "bootstrap/functions/data" (dict "key" $key "page" .Page) .Page $key }}
 {{- with $data }}
 <div class="d-flex bs-img-grid flex-wrap gap-1 justify-content-center">
   {{- range . }}
     {{- $img := partial "images/image" (dict
+      "Page" $page
       "Filename" .src
       "ClassName" "bs-img-grid-item-img"
       "Alt" .title


### PR DESCRIPTION
solves #115 


another solution might be to not use "with $data" and instead use "if $data" as `.` got redefined.