### PR TITLE
fix(collapse): use .Page.RenderString to render .Inner

### DIFF
--- a/assets/mods/bootstrap/scss/_collapse.scss
+++ b/assets/mods/bootstrap/scss/_collapse.scss
@@ -1,0 +1,15 @@
+.collapse-toggle {
+  padding-left: 0.25rem !important;
+
+  &::before {
+    content: "\2BC8";
+    margin-right: 0.25rem;
+  }
+
+  &[aria-expanded=true] {
+    &::before {
+      transform: rotate(90deg);
+      display: inline-block;
+    }
+  }
+}

--- a/assets/mods/bootstrap/scss/index.scss
+++ b/assets/mods/bootstrap/scss/index.scss
@@ -1,1 +1,2 @@
 @import 'alert';
+@import 'collapse';

--- a/layouts/partials/bootstrap/collapse.html
+++ b/layouts/partials/bootstrap/collapse.html
@@ -2,18 +2,33 @@
 {{- $heading := "" -}}
 {{- $style := "primary" -}}
 {{- $expand := false -}}
+{{- $rounded := true -}}
+{{- $border := true }}
 {{- if .IsNamedParams -}}
   {{- $heading = .Get "heading" -}}
   {{- with .Get "style" }}{{ $style = . }}{{ end -}}
   {{- with .Get "expand" }}{{ $expand = . }}{{ end -}}
-{{- else -}}
-  {{- $heading = .Get 0 -}}
+  {{- with .Get "rounded" }}{{ $rounded = . }}{{ end -}}
+  {{- with .Get "border" }}{{ $border = . }}{{ end -}}
+{{- else }}
+  {{- $heading = .Get 0 }}
   {{- with .Get 1 }}{{ $style = . }}{{ end -}}
   {{- with .Get 2 }}{{ $expand = . }}{{ end -}}
 {{- end -}}
-{{- $heading := printf
-  `<a type="button" class="collapse-toggle text-decoration-none text-bg-%s px-2" data-bs-toggle="collapse" href="#%s" aria-expanded="%s" aria-controls="%s">%s</a>`
-  $style $id (cond $expand `true` `false`) $id $heading
-}}
-{{- $inner := printf `<div class="collapse ps-2 pt-2 mb-3 border-top border-start border-%s%s" id="%s">%s</div>` $style (cond $expand ` show` ``) $id .Inner }}
-{{- printf `<div class="collapse-wrapper mb-3">%s%s</div>` $heading $inner | safeHTML }}
+<div
+  class="collapse-wrapper mb-3">
+  <a
+    type="button"
+    class="collapse-toggle text-decoration-none text-bg-{{ $style }} px-2"
+    data-bs-toggle="collapse"
+    href="#{{ $id }}"
+    aria-expanded="{{ cond $expand `true` `false` }}"
+    aria-controls="{{ $id }}">
+    {{- $heading -}}
+  </a>
+  <div
+    class="collapse{{ cond $border ` border` `` }}{{ cond $rounded ` rounded-bottom rounded-end` `` }} px-2 pt-2 pb-1 mb-3{{ cond $expand ` show` `` }}"
+    id="{{ $id }}">
+    {{ trim .Inner "\r\n" | .Page.RenderString }}
+  </div>
+</div>


### PR DESCRIPTION
style(collapse): add the triangle indicator
feat(collapse): add the border and rounded named parameters

Fixes #141 