### PR TITLE
fix(container): use bgColor as the second background to avoid not see…

### DIFF
--- a/layouts/partials/bootstrap/container.html
+++ b/layouts/partials/bootstrap/container.html
@@ -20,24 +20,34 @@
 {{- with $class }}{{ $classes = $classes | append . }}{{ end }}
 {{- $style := slice }}
 {{- if ne $bg "" }}
+  {{- $bgRes := false }}
   {{- $classes = $classes | append "" }}
   {{- with .Page.Resources.Get $bg }}
+    {{- $bgRes = . }}
     {{- $bg = .RelPermalink }}
   {{- else }}
     {{- with resources.Get $bg }}
+      {{- $bgRes = . }}
       {{- $bg = .RelPermalink }}
     {{- end }}
   {{- end }}
+  {{- with and (eq $bgColor "") $bgRes }}
+    {{- with index .Colors 0 }}
+      {{- $bgColor = . }}
+    {{- end }}
+  {{- end }}
   {{- $style = $style | append
-    (printf "background-image: url(%s)" $bg)
+    (cond
+      (ne $bgColor "")
+      (printf "background: url(%s), %s" $bg $bgColor)
+      (printf "background-image: url(%s)" $bg))
     "background-size: cover"
   }}
-{{- end }}
-{{- with $bgColor }}
+{{- else if ne $bgColor "" }}
   {{- $style = $style | append (printf "background-color: %s" .) }}
 {{- end }}
 <div
   class="{{ delimit $classes ` ` }}"
-  {{ with $style }}{{ delimit . `;` | printf `style="%s"` | safeHTMLAttr }}{{ end }}>
+  {{ with $style }}{{ delimit . `; ` | printf `style="%s"` | safeHTMLAttr }}{{ end }}>
   {{ .Inner }}
 </div>


### PR DESCRIPTION
…ing text before successfully loading background images

The bgColor will be fallback to primary color of background resource image if not set

| Previous | With this patch |
| -- | -- |
| ![peek_4](https://github.com/hugomods/bootstrap/assets/17720932/46058650-f3f5-4152-a610-988934fffbec) | ![peek_3](https://github.com/hugomods/bootstrap/assets/17720932/b6e47e52-aee4-4911-ba4f-3eeac8716c6b) |