### PR TITLE
[Proposal] Use 'Scratch Pad' instead of `now.UnixNano`

### DIFF
--- a/layouts/partials/bootstrap/collapse.html
+++ b/layouts/partials/bootstrap/collapse.html
@@ -1,4 +1,8 @@
-{{- $id := printf "collapse-%d" now.UnixNano -}}
+{{- if not (.Page.Scratch.Get "collapseCounter") -}}
+  {{- .Page.Scratch.Set "collapseCounter" 0 -}}
+{{- end -}}
+{{- .Page.Scratch.Add "collapseCounter" 1 -}}
+{{- $id := printf "collapse-%d" (.Page.Scratch.Get "collapseCounter") -}}
 {{- $heading := "" -}}
 {{- $style := "primary" -}}
 {{- $expand := false -}}


### PR DESCRIPTION
Using `now.UnixNano` will change `<a>`'s ID every time the site is built.

In most cases, this is fine. But in my case, it didn't work well. When testing my site locally, a few `bs/collapse` shared the same ID. This made them to be opened or closed at once, together. I don't know why that happened, because that means multiple `bs/collapse` were generated at the same time, and the chance is highly unlikely.

So I changed the `$id` part to be like this:
```html
{{- $id := printf "collapse-%s" (delimit (shuffle (seq 1 9)) "") -}}
```
This also works for creating distinct IDs.

Both `now.UnixNano` and `delimit (shuffle (seq 1 9)) ""` have a problem. They will create a different ID every time they are called. If you build a site twice without changing anything, the build results won't be the same because of the different IDs.

After a brief search, I've found that Hugo supports a [per-page scratch pad](https://gohugo.io/methods/page/scratch/). Since the scratch pad is only shared on a single page, we can safely use incremental numbers for the IDs because no same number will occur on a single page if we increment it properly.

I tested this for my site, and it works as intended. It even worked for nested `bs/collapse`. The only difference is that I use `%03d` instead of `%d` for numbers.

This might increase build time because now Hugo has to assign a map for each page, instead of just getting `now.UnixNano`.